### PR TITLE
Hackily allow RPS ASEL using TopSky

### DIFF
--- a/vSMR/SMRPlugin.hpp
+++ b/vSMR/SMRPlugin.hpp
@@ -13,7 +13,7 @@
 #include "Logger.h"
 
 #define MY_PLUGIN_NAME      "vSMR"
-#define MY_PLUGIN_VERSION   "v1.9.0-beta6"
+#define MY_PLUGIN_VERSION   "v1.9.0-beta7"
 #define MY_PLUGIN_DEVELOPER "Pierre Ferran, Even Rognlien, Lionel Bischof, Daniel Lange, Juha Holopainen, Keanu Czirjak, Nicola Macoir, Stef Pletinck"
 #define MY_PLUGIN_COPYRIGHT "GPL v3"
 #define MY_PLUGIN_VIEW_AVISO  "SMR radar display"


### PR DESCRIPTION
TopSky blocks our interaction objects on RPS and symbols. I say f that and just call out to the windows APIs and check for clicks myself.

As explained in the comment, this is dirty and weird, but functional