### PR TITLE
Add Show STUP filter

### DIFF
--- a/vSMR/Constant.hpp
+++ b/vSMR/Constant.hpp
@@ -334,6 +334,7 @@ constexpr int FILTER_NON_ASSUMED = 8892;
 constexpr int FILTER_SHOW_FREE = 8893;
 constexpr int FILTER_SHOW_ON_BLOCKS = 8894;
 constexpr int FILTER_SHOW_NSTS = 8895;
+constexpr int FILTER_SHOW_STUP = 8896;
 
 // Brightness update
 constexpr int RIMCAS_BRIGHTNESS_LABEL = 301;

--- a/vSMR/Filters.h
+++ b/vSMR/Filters.h
@@ -6,6 +6,7 @@ struct Filters
 	bool show_nonmine : 1;
 	bool show_on_blocks : 1;
 	bool show_nsts : 1;
+	bool show_stup : 1;
 };
 
 inline Filters new_filters()
@@ -15,12 +16,18 @@ inline Filters new_filters()
 		true,
 		true,
 		true,
+		true,
 	};
 }
 
 inline char char_from_filters(const Filters &filters)
 {
-	char converted = 0;
+	// Initialize the top 4 bits to true
+	// Those were unused and thus 0 before introduction of show_stup,
+	// which would make show_stup default to false on existing installs.
+	// Thus, we set bits if the field is set for the low bits,
+	// and unset them for the high bits.
+	unsigned char converted = 0xf0;
 	if (filters.show_free)
 	{
 		converted |= 1;
@@ -37,15 +44,21 @@ inline char char_from_filters(const Filters &filters)
 	{
 		converted |= (1 << 3);
 	}
-	return converted;
+	if (filters.show_stup)
+	{
+		converted &= ~(1 << 4);
+	}
+	return static_cast<char>(converted);
 }
 
 inline Filters filters_from_char(const char filters)
 {
+	// Same as above, low bits: 1 means true, high bits are flipped.
 	return Filters{
 		(filters & 1) > 0,
 		(filters & (1 << 1)) > 0,
 		(filters & (1 << 2)) > 0,
 		(filters & (1 << 3)) > 0,
+		(filters & (1 << 4)) == 0,
 	};
 }

--- a/vSMR/SMRRadar.cpp
+++ b/vSMR/SMRRadar.cpp
@@ -82,9 +82,10 @@ void CSMRRadar::draw_target(TagDrawingContext& tdc, CRadarTarget& rt)
 	if (!filters.show_on_blocks && gate_target->isOnBlocks(this, &rt))
 		isAcDisplayed = false;
 
-	const char* callsign = fp.GetCallsign();
 	// NSTS shows up as "" here
 	if (!filters.show_nsts && strlen(fp.GetGroundState()) == 0)
+		isAcDisplayed = false;
+	if (!filters.show_stup && strcmp(fp.GetGroundState(), "STUP") == 0)
 		isAcDisplayed = false;
 
 	if (!isAcDisplayed)
@@ -1193,6 +1194,8 @@ void CSMRRadar::OnClickScreenObject(int ObjectType, const char* sObjectId, POINT
 												filters.show_on_blocks ? POPUP_ELEMENT_CHECKED : POPUP_ELEMENT_UNCHECKED);
 			GetPlugIn()->AddPopupListElement("Show NSTS", "", FILTER_SHOW_NSTS, false,
 												filters.show_nsts ? POPUP_ELEMENT_CHECKED : POPUP_ELEMENT_UNCHECKED);
+			GetPlugIn()->AddPopupListElement("Show STUP", "", FILTER_SHOW_STUP, false,
+												filters.show_stup ? POPUP_ELEMENT_CHECKED : POPUP_ELEMENT_UNCHECKED);
 			GetPlugIn()->AddPopupListElement("Close", "", RIMCAS_CLOSE, false, POPUP_ELEMENT_NO_CHECKBOX, false, true);
 		}
 
@@ -1710,6 +1713,11 @@ void CSMRRadar::OnFunctionCall(int FunctionId, const char* sItemString, POINT Pt
 	if (FunctionId == FILTER_SHOW_NSTS)
 	{
 		filters.show_nsts = !filters.show_nsts;
+	}
+
+	if (FunctionId == FILTER_SHOW_STUP)
+	{
+		filters.show_stup = !filters.show_stup;
 	}
 }
 


### PR DESCRIPTION
In combination with the Show NSTS filter,
this allows hiding NSTS and STUP filter;
or only showing PUSH and above.
Very helpful

Fixes #38