### PR TITLE
Replace backup tags by alt-mode

### DIFF
--- a/vSMR/SMRRadar.hpp
+++ b/vSMR/SMRRadar.hpp
@@ -50,7 +50,7 @@ class CSMRRadar :
 {
 private:
 	GateTarget * gate_target;
-	void draw_target(TagDrawingContext& tdc, CRadarTarget& rt);
+	void draw_target(TagDrawingContext& tdc, CRadarTarget& rt, const bool alt_mode = false);
 	bool shift_top_bar = false;
 	bool show_err_lines = true;
 public:


### PR DESCRIPTION
Introduces ALT-mode, which when holding ALT assumes all tags to be correlated.

Removes the back up TAGs, because why do we need that ;)

Implements #37