### PR TITLE
Replace some GDI calls by GDI+

### DIFF
--- a/vSMR/SMRRadar.cpp
+++ b/vSMR/SMRRadar.cpp
@@ -2471,9 +2471,6 @@ void CSMRRadar::OnRefresh(HDC hDC, int Phase)
 		{
 			if (RimcasInstance->ClosedRunway[RwName])
 			{
-				CPen RedPen(PS_SOLID, 2, RGB(150, 0, 0));
-				CPen* oldPen = dc.SelectObject(&RedPen);
-
 				if (CurrentConfig->isCustomRunwayAvail(getActiveAirport(), runway_name, runway_name2))
 				{
 					const Value& Runways = CustomMap["runways"];
@@ -2532,8 +2529,6 @@ void CSMRRadar::OnRefresh(HDC hDC, int Phase)
 
 					graphics.FillPolygon(&SolidBrush(Color(150, 0, 0)), lpPoints, w);
 				}
-
-				dc.SelectObject(oldPen);
 			}
 		}
 	}


### PR DESCRIPTION
GDI's SelectObject behaviour has a nasty habit of leaking memory, this MR fixes #52 by replacing a portion by GDI+ where practical.
Important to replace were the transponder symbols as there are a lot of those and selecting the pens allocated so much all the time.