### PR TITLE
Add Assigned altitude field property

### DIFF
--- a/vSMR/InsetWindow.cpp
+++ b/vSMR/InsetWindow.cpp
@@ -2,9 +2,10 @@
 #include "InsetWindow.h"
 
 
-CInsetWindow::CInsetWindow(int Id)
+CInsetWindow::CInsetWindow(int Id, CSMRRadar* radar)
 {
 	m_Id = Id;
+	this->radar = radar;
 }
 
 CInsetWindow::~CInsetWindow() = default;
@@ -390,7 +391,7 @@ void CInsetWindow::render(HDC hDC, CSMRRadar* radar_screen, Graphics* gdi, POINT
 		// Drawing the tags, what a mess
 
 		// ----- Generating the replacing map -----
-		map<string, string> TagReplacingMap = CSMRRadar::GenerateTagData(rt, fp, radar_screen->IsCorrelated(fp, rt), radar_screen->CurrentConfig->getActiveProfile()["filters"]["pro_mode"]["enable"].GetBool(), radar_screen->GetPlugIn()->GetTransitionAltitude(), radar_screen->CurrentConfig->getActiveProfile()["labels"]["use_aspeed_for_gate"].GetBool(), icao);
+		map<string, string> TagReplacingMap = radar->GenerateTagData(rt, fp, radar_screen->IsCorrelated(fp, rt), radar_screen->CurrentConfig->getActiveProfile()["filters"]["pro_mode"]["enable"].GetBool(), radar_screen->GetPlugIn()->GetTransitionAltitude(), radar_screen->CurrentConfig->getActiveProfile()["labels"]["use_aspeed_for_gate"].GetBool(), icao);
 
 		// ----- Generating the clickable map -----
 		map<string, int> TagClickableMap;
@@ -450,8 +451,6 @@ void CInsetWindow::render(HDC hDC, CSMRRadar* radar_screen, Graphics* gdi, POINT
 
 		int TagWidth = 0, TagHeight = 0;
 		RectF mesureRect;
-		gdi->MeasureString(L" ", wcslen(L" "), radar_screen->customFonts[radar_screen->currentFontSize], PointF(0, 0), &Gdiplus::StringFormat(), &mesureRect);
-		int blankWidth = (int)mesureRect.GetRight();
 
 		mesureRect = RectF(0, 0, 0, 0);
 		gdi->MeasureString(L"AZERTYUIOPQSDFGHJKLMWXCVBN", wcslen(L"AZERTYUIOPQSDFGHJKLMWXCVBN"),
@@ -491,9 +490,6 @@ void CInsetWindow::render(HDC hDC, CSMRRadar* radar_screen, Graphics* gdi, POINT
 					radar_screen->customFonts[radar_screen->currentFontSize], PointF(0, 0), &Gdiplus::StringFormat(), &mesureRect);
 
 				TempTagWidth += (int)mesureRect.GetRight();
-
-				if (j != line.Size() - 1)
-					TempTagWidth += (int)blankWidth;
 			}
 
 			TagWidth = max(TagWidth, TempTagWidth);
@@ -578,7 +574,6 @@ void CInsetWindow::render(HDC hDC, CSMRRadar* radar_screen, Graphics* gdi, POINT
 					radar_screen->AddScreenObject(TagClickableMap[element], rt.GetCallsign(), ItemRect, false, radar_screen->GetBottomLine(rt.GetCallsign()).c_str());
 
 					widthOffset += (int)mRect.GetRight();
-					widthOffset += blankWidth;
 				}
 
 				heightOffset += oneLineHeight;

--- a/vSMR/InsetWindow.h
+++ b/vSMR/InsetWindow.h
@@ -11,7 +11,7 @@ using namespace EuroScopePlugIn;
 class CInsetWindow
 {
 public:
-	CInsetWindow(int Id);
+	CInsetWindow(int Id, CSMRRadar* radar);
 	virtual ~CInsetWindow();
 
 	// Definition
@@ -32,5 +32,7 @@ public:
 private:
 	string icao;
 	map<string, CPosition> AptPositions;
+
+	CSMRRadar* radar;
 };
 

--- a/vSMR/SMRRadar.hpp
+++ b/vSMR/SMRRadar.hpp
@@ -171,7 +171,7 @@ public:
 
 	//---GenerateTagData--------------------------------------------
 
-	static map<string, string> GenerateTagData(CRadarTarget Rt, CFlightPlan fp, bool isAcCorrelated, bool isProMode, int TransitionAltitude, bool useSpeedForGates, string ActiveAirport);
+	map<string, string> GenerateTagData(CRadarTarget Rt, CFlightPlan fp, bool isAcCorrelated, bool isProMode, int TransitionAltitude, bool useSpeedForGates, string ActiveAirport);
 
 	inline virtual bool is_manually_correlated(const char* system_id)
 	{

--- a/vSMR/TagDrawingContext.hpp
+++ b/vSMR/TagDrawingContext.hpp
@@ -12,7 +12,6 @@ struct TagDrawingContext
 {
 	Gdiplus::Graphics* graphics;
 	int line_height;
-	int blank_width;
 	const rapidjson::Value* labels_settings;
 	const Gdiplus::SolidBrush* squawk_error_color;
 	const Gdiplus::SolidBrush* rimcas_text_color;

--- a/vSMR/UIHelpers.cpp
+++ b/vSMR/UIHelpers.cpp
@@ -126,3 +126,11 @@ std::optional<std::vector<std::vector<std::string>>> UIHelper::parse_label_lines
 	return { output };
 }
 
+std::string UIHelper::altitude(const int x, const unsigned int transition)
+{
+	if (x > transition)
+		return "F" + std::to_string(x / 100);
+	else
+		return "A" + std::to_string(x / 100);
+}
+

--- a/vSMR/UIHelpers.hpp
+++ b/vSMR/UIHelpers.hpp
@@ -12,4 +12,5 @@ static string getEnumString(TagTypes type);
 static void drawLeaderLine(const std::vector<PointF>& points, const PointF& acPos, const Gdiplus::Pen* pen, Gdiplus::Graphics* graphics);
 static std::vector<PointF> grow_border(const std::vector<PointF>& border, const int growth, const bool right_align);
 static std::optional<std::vector<std::vector<std::string>>> parse_label_lines(const Value& value);
+static std::string altitude(const int x, const unsigned int transition = 6000);
 };


### PR DESCRIPTION
Because of the need for transition altitude,
this did mean I had to add references to the radar screen in some places.

Also removed automatic spacing between TAG items and added "space" as an item.

Fixes #74