### PR TITLE
Use connected aircraft type

### DIFF
--- a/vSMR/PlaneShapeBuilder.h
+++ b/vSMR/PlaneShapeBuilder.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <filesystem>
 #include <map>
+#include <optional>
 #include <random>
 #include <vector>
 
@@ -22,7 +23,7 @@ public:
 	PlaneShapeBuilder();
 	///	Number of points in resulting shape
 	static constexpr size_t shape_size = 9;
-	std::vector < CPosition > build(const EuroScopePlugIn::CRadarTargetPositionData &position, const EuroScopePlugIn::CFlightPlan &flight_plan, int time_offset = 0);
+	std::vector < CPosition > build(const EuroScopePlugIn::CRadarTargetPositionData &position, const EuroScopePlugIn::CFlightPlan &flight_plan, const optional<std::string>& known_type, int time_offset = 0);
 	void init();
 	void radar_scan();
 private:
@@ -31,5 +32,7 @@ private:
 	std::map<std::string, AircraftType> types;
 	size_t load_file(std::istream& str);
 	unsigned int extra_seed = 0;
+
+	static std::optional<std::string> find_type(const EuroScopePlugIn::CFlightPlan& fp, const std::optional<std::string>& known_type);
 };
 

--- a/vSMR/SMRPlugin.hpp
+++ b/vSMR/SMRPlugin.hpp
@@ -24,21 +24,27 @@ using namespace EuroScopePlugIn;
 class CSMRPlugin :
 	public EuroScopePlugIn::CPlugIn
 {
+	// Map of (identifier, callback)
+	std::map<std::string, std::pair<std::string, std::clock_t>> type_map;
+
+	void cleanup_type_map();
+
 public:
 	CSMRPlugin();
 	virtual ~CSMRPlugin();
 
 	//---OnCompileCommand------------------------------------------
 
-	bool OnCompileCommand(const char * sCommandLine) override;
+	bool OnCompileCommand(const char* sCommandLine) override;
 
 	//---OnFunctionCall------------------------------------------
 
-	void OnFunctionCall(int FunctionId, const char * sItemString, POINT Pt, RECT Area) override;
+	void OnFunctionCall(int FunctionId, const char* sItemString, POINT Pt, RECT Area) override;
 
 	//---OnGetTagItem------------------------------------------
 
-	void OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int ItemCode, int TagData, char sItemString[16], int * pColorCode, COLORREF * pRGB, double * pFontSize) override;
+	void OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int ItemCode, int TagData, char sItemString[16],
+	                  int* pColorCode, COLORREF* pRGB, double* pFontSize) override;
 
 	//---OnFlightPlanDisconnect------------------------------------------
 
@@ -50,6 +56,10 @@ public:
 
 	//---OnRadarScreenCreated------------------------------------------
 
-	CRadarScreen * OnRadarScreenCreated(const char * sDisplayName, bool NeedRadarContent, bool GeoReferenced, bool CanBeSaved, bool CanBeCreated) override;
-};
+	CRadarScreen* OnRadarScreenCreated(const char* sDisplayName, bool NeedRadarContent, bool GeoReferenced,
+	                                   bool CanBeSaved, bool CanBeCreated) override;
 
+	void OnPlaneInformationUpdate(const char* sCallsign, const char* sLivery, const char* sPlaneType) override;
+
+	std::optional<std::string> type_for(const std::string& callsign) const;
+};

--- a/vSMR/SMRRadar.cpp
+++ b/vSMR/SMRRadar.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <boost/geometry.hpp>
 #include "PlaneShapeBuilder.h"
+#include "SMRPlugin.hpp"
 using namespace std::string_literals;
 
 ULONG_PTR m_gdiplusToken;
@@ -2601,7 +2602,7 @@ void CSMRRadar::OnRefresh(HDC hDC, int Phase)
 			{
 				scans = found->second;
 			}
-			const auto shape = plane_shape_builder->build(rt.GetPosition(), fp, scans);
+			const auto shape = plane_shape_builder->build(rt.GetPosition(), fp, static_cast<CSMRPlugin*>(GetPlugIn())->type_for(fp.GetCallsign()), scans);
 			PointF lpPoints[PlaneShapeBuilder::shape_size];
 			for (auto i = 0; i < shape.size(); ++i)
 			{
@@ -3333,7 +3334,7 @@ void CSMRRadar::draw_after_glow(CRadarTarget rt, Graphics& graphics)
 			scans = found->second;
 		}
 
-		const auto shape = plane_shape_builder->build(pos, fp, scans - i - 1);
+		const auto shape = plane_shape_builder->build(pos, fp, {}, scans - i - 1);
 
 		// Convert CPositions to pixel positions
 		for (auto j = 0; j < shape.size(); ++j)


### PR DESCRIPTION
Thanks to the suggestion of the man Lars Bergmann, we're now using the aircraft type as sent by FSD,
rather than the one in the flightplan.
We can still fall back to flightplan should no FSD info be avilable, as the mechanism is rather fragile.

Getting this data involves schlepping it from the CPlugin, to the CRadarScreen, but it works!

For our controllers, this means aircraft without a flight plan will no longer all be shaped like a cessna, or magically change size after filing a plan. Woo!

Fixes #80